### PR TITLE
Add space and org to route names when deploying, to prevent route name collisions

### DIFF
--- a/api_proxy_manifest.yml.src
+++ b/api_proxy_manifest.yml.src
@@ -5,8 +5,8 @@ applications:
     buildpacks:
       - python_buildpack
     routes:
-    - route: api-proxy.apps.internal
-    - route: api-proxy.app.cloud.gov
+    - route: ${ORG}-${SPACE_NODOT}-api-proxy.apps.internal
+    - route: ${ORG}-${SPACE_NODOT}-api-proxy.app.cloud.gov
     env:
       API_ENDPOINT: ${API_ENDPOINT}
       API_KEY: ${API_KEY}

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,8 +2,11 @@
 set -e  # Exit on any error
 
 # Retrieve the current targeted org and space
-ORG=$(cf target | awk -F': ' '/org:/ {print $2}')
-SPACE=$(cf target | awk -F': ' '/space:/ {print $2}')
+ORG=$(cf target | awk '/org:/ {print $2}')
+SPACE=$(cf target | awk '/space:/ {print $2}')
+
+# We will use $ORG and $SPACE to get unique host names. Sandbox space names have dots, so remove those.
+SPACE_NODOT=${SPACE//\./-}
 
 # Display current target information
 echo "🔍 You are deploying to:"
@@ -30,7 +33,14 @@ fi
 # Replace placeholders in API Proxy manifest and generate a new YML file
 sed -e "s|\${API_ENDPOINT}|$API_ENDPOINT|g" \
     -e "s|\${API_KEY}|$API_KEY|g" \
+    -e "s|\${ORG}|$ORG|g" \
+    -e "s|\${SPACE_NODOT}|$SPACE_NODOT|g" \
     api_proxy_manifest.yml.src > api_proxy_manifest.yml
+
+# Replace placeholders in test client manifest and generate a new YML file
+sed -e "s|\${ORG}|$ORG|g" \
+    -e "s|\${SPACE_NODOT}|$SPACE_NODOT|g" \
+    test_client_manifest.yml.src > test_client_manifest.yml
 
 echo "✅ Configuration prepared"
 
@@ -44,17 +54,17 @@ function ensure_route {
   if cf routes | grep -q "${hostname}.${domain}"; then
     return 0  # Route already exists, no need to output anything
   else
-    cf create-route "${domain}" --hostname "${hostname}" > /dev/null 2>&1
+    cf create-route "${domain}" --hostname "${hostname}"
     new_routes+=("${hostname}.${domain}")
   fi
 }
 
 # Ensure routes exist before deployment
 echo "🔄 Checking routes..."
-ensure_route "apps.internal" "api-proxy"
-ensure_route "app.cloud.gov" "api-proxy"
-ensure_route "apps.internal" "test-client"
-ensure_route "app.cloud.gov" "test-client"
+ensure_route "apps.internal" "${ORG}-${SPACE_NODOT}-api-proxy"
+ensure_route "app.cloud.gov" "${ORG}-${SPACE_NODOT}-api-proxy"
+ensure_route "apps.internal" "${ORG}-${SPACE_NODOT}-test-client"
+ensure_route "app.cloud.gov" "${ORG}-${SPACE_NODOT}-test-client"
 
 # If any routes were created, display them in a single message
 if [[ ${#new_routes[@]} -gt 0 ]]; then
@@ -65,7 +75,7 @@ fi
 
 # Deploy API Proxy
 echo "🚀 Deploying API Proxy..."
-if cf push -f api_proxy_manifest.yml > /dev/null 2>&1; then
+if cf push -f api_proxy_manifest.yml ; then
   echo "✅ API Proxy deployed successfully."
 else
   echo "❌ API Proxy deployment failed."
@@ -74,7 +84,7 @@ fi
 
 # Deploy Test Client
 echo "🚀 Deploying Test Client..."
-if cf push -f test_client_manifest.yml > /dev/null 2>&1; then
+if cf push -f test_client_manifest.yml ; then
   echo "✅ Test Client deployed successfully."
 else
   echo "❌ Test Client deployment failed."
@@ -93,7 +103,7 @@ fi
 
 # Clean up generated manifest
 rm -f api_proxy_manifest.yml
+rm -f test_client__manifest.yml
 echo "✅ Cleanup complete."
 
 echo "🎉 Deployment completed successfully!"
-

--- a/test_client_manifest.yml.src
+++ b/test_client_manifest.yml.src
@@ -7,5 +7,5 @@ applications:
     command: sleep infinity # Keeps the instance running for manual testing
     health-check-type: process # Prevents Cloud Foundry from expecting an open port
     routes:
-      - route: test-client.apps.internal
-      - route: test-client.app.cloud.gov
+      - route: ${ORG}-${SPACE_NODOT}-test-client.apps.internal
+      - route: ${ORG}-${SPACE_NODOT}-test-client.app.cloud.gov


### PR DESCRIPTION
Cloud Foundry failed on deployment for me, because the api-proxy.apps.internal and api-proxy.app.cloud.gov routes were already taken. 
```
Routes cannot be mapped to destinations in different spaces
```

So I'm prepending the org and space names (with . in space name converted to -) to the route names. It makes for extra-long route names, but it works. 

I also modified the `cf deploy` lines to emit their output while troubleshooting, and decided to leave it that way for now. 